### PR TITLE
Fix startup shortcut

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
     - if not exist "%PREFIX%\Menu" mkdir "%PREFIX%\Menu"  # [win]
     - copy /Y "%RECIPE_DIR%\papylio.ico" "%PREFIX%\Menu\papylio.ico"  # [win]
     - copy /Y "%RECIPE_DIR%\papylio_menu.json" "%PREFIX%\Menu\papylio_menu.json"  # [win]
-  number: 1
+  number: 2
 
 requirements:
   host:

--- a/recipe/papylio_menu.json
+++ b/recipe/papylio_menu.json
@@ -6,7 +6,7 @@
       "name": "Papylio",
 	  "description": "Software for surface-based single-molecule fluorescence data analysis",
 	  "command": ["python", "-m", "papylio"],
-	  "pywscript": "-m papylio",
+	  "pyscript": "-m papylio",
 	  "icon": "{{ MENU_DIR }}/papylio.{{ ICON_EXT }}",
       "platforms": {
         "linux": {},


### PR DESCRIPTION
Switch from using pythonw to python, to avoid an error when writing to the console, which is not there in pythonw.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
